### PR TITLE
Keep a remote copy of the cache db saved on S3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "mime": "~1.2.9",
     "backoff": "~2.3.0",
     "xtend": "~2.0.6",
-    "knox": "~0.8.3"
+    "knox": "~0.8.3",
+    "event-stream": "3.0.16",
+    "level": "0.10.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This is not quite working yet--there is a problem in the `getCache` callback where the stream events aren't being triggered. Suggested usage like:

``` js
var s3sync = require('s3sync')
var readdirp = require('readdirp')

var syncer = s3sync({
    key: YOUR_KEY,
    secret: YOUR_SECRET,
    bucket: YOUR_BUCKET
})
var files = readdirp({
    root: __dirname + '/build'
})

syncer.getCache(function(err){
    files.pipe(syncer)
        .on('data', function(file){ console.log(file.fullPath + ' -> ' + file.url) })
        .once('end', function(){
            syncer.putCache(function(){
                console.log('Done!')
            })
        })
})
```

Also added `level` as a dependency--I think that would be the typical use case, no?

Fixes issue #1
