### PR TITLE
If there is no syncfilehash header, this object didn't come from s3-sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,8 @@ function s3syncer(db, options) {
       client.headFile(relative, function(err, res) {
         if (err) return next(err)
         if (
-          res.statusCode === 404 || (
+          res.statusCode === 404 ||
+          ! res.headers['x-amz-meta-syncfilehash'] || (
           res.headers['x-amz-meta-syncfilehash'] &&
           res.headers['x-amz-meta-syncfilehash'] !== details.md5
         )) return uploadFile(details, next)


### PR DESCRIPTION
This is to handle [issue #13](https://github.com/hughsk/s3-sync/issues/13).

When I'm sloppy/rushed, I sometimes tweak "just one file, what could it hurt?" with something like s3cmd.  When I do that, s3-sync loses track of the file's MD5, but does so in a way that makes it just act like there is no change, ever.

Since `x-amz-meta-syncfilehash` is a custom header, its absence means this file wasn't PUT originally using s3-sync, and there's really no way to compare it, reasonably.  Maybe one could fall back to etag and comparing md5 of the file, but `details.md5` isn't just for the file, so that's not so good.