### PR TITLE
Replace files without 'x-amz-meta-syncfilehash' header

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,6 @@ function s3syncer(db, options) {
         if (err) return next(err)
         if (
           res.statusCode === 404 || (
-          res.headers['x-amz-meta-syncfilehash'] &&
           res.headers['x-amz-meta-syncfilehash'] !== details.md5
         )) return uploadFile(details, next)
         if (res.statusCode >= 300) return next(new Error('Bad status code: ' + res.statusCode))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-sync",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A streaming upload tool for Amazon S3",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
It didn't seem to be replacing files already on S3 but which didn't have the `x-amz-meta-syncfilehash` header.