### PR TITLE
Allow explicitly specified content-types

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function s3syncer(db, options) {
       var headers = xtend({
           'x-amz-acl': options.acl
         , 'x-amz-meta-syncfilehash': details.md5
-        , 'Content-Type': mime.lookup(absolute)
+        , 'Content-Type': details.contentType || mime.lookup(absolute)
       }, options.headers)
 
       client.putFile(absolute, relative, headers, function(err, res) {


### PR DESCRIPTION
Hello,

I'd like to be able to explicitly specify the content-type of certain files (specifically ones with no extension) so I can set them to text/html (I'm making an S3-powered website and I don't want extensions or trailing slashes).

Let me know what you think.

Cheers,
Matt
